### PR TITLE
Fixing broken ACT Scraper.

### DIFF
--- a/scrapers/act_scraper.rb
+++ b/scrapers/act_scraper.rb
@@ -31,7 +31,7 @@ class ACTScraper < Scraper
       
       lines[1].at('strong').remove
       lines[2].at('strong').remove
-      lines[4].at('b').remove
+      lines[4].at('strong').remove
       lines[5].at('strong').remove
       stripped = lines.map{|l| l.inner_text.strip}
 


### PR DESCRIPTION
Looks like a changed html tag on the ACTPLA broke the parser, small change here to the tag to look for in removing unwanted header details to fix it.
