### PR TITLE
Fix kingston

### DIFF
--- a/scraperwiki_scrapers/kingston.rb
+++ b/scraperwiki_scrapers/kingston.rb
@@ -8,8 +8,7 @@ agent = Mechanize.new
 
 start_date = (Date.today-14).strftime('%d/%m/%Y')
 end_date = Date.today.strftime('%d/%m/%Y')
-url = "http://web.kingston.vic.gov.au/web/planning/?l=planning_register2&l1=#{start_date}&l2=#{end_date}&l3=lodged&i=&x=&c=&w="
-
+url = "http://www.kingston.vic.gov.au/planning/?l=planning_register2&l1=#{start_date}&l2=#{end_date}&l3=lodged&i=&x=&c=&w="
 page = agent.get(url)
 
 page.search('tr.item_row').each do |row|


### PR DESCRIPTION
A simple web address change broke http://www.planningalerts.org.au/authorities/kingston

However, scraperwiki is producing

```
On its last run it generated the following error: #<Errno::ENOSPC: No space left on device - /tmp/mechanize-raw20140118-4-g3zsji.lock>
```

I tweeted them about it, but consider fixed but not fully tested.

Pull request two: Now with added accuracy!
